### PR TITLE
feat: Folder building and globing support

### DIFF
--- a/build.dev.js
+++ b/build.dev.js
@@ -3,29 +3,10 @@ const { build } = require('esbuild');
 const path = require('path');
 const fs = require('fs');
 
-function getAllFiles(folder) {
-    let result = [];
-    const files = fs.readdirSync(folder);
-
-    for (const file of files) {
-        const filePath = path.join(folder, file);
-        const stats = fs.statSync(filePath);
-        if (stats.isDirectory()) {
-            result = result.concat(getAllFiles(filePath));
-        } else if (file.endsWith('.ts')) {
-            result.push(filePath);
-        }
-    }
-
-    return result;
-}
-
-async function buildFolder(folder, outdir, target, format, platform) {
+async function buildEntrypoint(entryPoint, outdir, target, format, platform) {
     try {
-        const entryPoints = getAllFiles(folder);
-
         await build({
-            entryPoints,
+            entryPoints: [entryPoint],
             bundle: true,
             outdir,
             target,
@@ -34,40 +15,87 @@ async function buildFolder(folder, outdir, target, format, platform) {
             minify: false,
         });
 
-        const folderName = folder.includes('server') ? 'server' : 'client';
+        const folderName = entryPoint.includes('server') ? 'server' : 'client';
         console.log(
             (await import('chalk')).default.green(
                 `[${folderName}]: Built successfully!`,
             ),
         );
     } catch (error) {
-        console.error(error);
-        process.exit(1);
+        console.error(
+            (await import('chalk')).default.red(
+                `Error building ${entryPoint}: ${error.message}`,
+            ),
+        );
     }
 }
 
-async function watchFolder(folder, outDir, target, format, platform) {
+async function watchFolder(entryPoint, outDir, target, format, platform) {
     const chalk = (await import('chalk')).default;
-    await buildFolder(folder, outDir, target, format, platform);
+    await buildEntrypoint(entryPoint, outDir, target, format, platform);
 
-    const watcher = chokidar.watch(`${folder}/**/*.ts`, {
-        ignoreInitial: true,
-    });
+    // Using the derived folder name to log the correct folder
+    const folderName = entryPoint.includes('server') ? 'server' : 'client';
+    console.log(chalk.yellow(`[${folderName}]: Watching for changes...`));
 
-    console.log(chalk.yellow(`[${folder}]: Watching for changes...`));
+    chokidar
+        .watch(path.dirname(entryPoint), {
+            ignoreInitial: true,
+        })
+        .on('change', async (event, path) => {
+            // Remove everything before the folder name
+            event = event.replace(__dirname, '');
 
-    watcher.on('change', async (filePath) => {
-        console.log(chalk.yellow(`[${folder}]: File changed: ${filePath}`));
-        await buildFolder(folder, outDir, target, format, platform);
-    });
+            console.log(
+                chalk.yellow(
+                    `[${folderName}]: File changed: ${event} - Rebuilding...`,
+                ),
+            );
+
+            await buildEntrypoint(entryPoint, outDir, target, format, platform);
+        });
 }
 
 async function watchAll() {
     const folders = ['server', 'client'];
 
     for (const folder of folders) {
+        const folderPath = path.join(__dirname, folder);
+
+        // Find server.ts or client.ts (our entrypoints)
+        let entryPoint = fs.readdirSync(folderPath);
+
+        if (!entryPoint) {
+            console.log(
+                (await import('chalk')).default.red(
+                    `[${folder}]: No results returned from readdirSync. Please make sure the ${folder} folder contains a entrypoint file (server.ts or client.ts).`,
+                ),
+            );
+            process.exit(1);
+        }
+
+        // Check if we have an entrypoint
+        if (!entryPoint.includes(`${folder}.ts`)) {
+            console.log(
+                (await import('chalk')).default.red(
+                    `[${folder}]: No entrypoint found! Please create a entrypoint file (server.ts or client.ts) in the ${folder} folder.`,
+                ),
+            );
+            process.exit(1);
+        }
+
+        entryPoint = entryPoint.find((file) => {
+            return file.endsWith('.ts') && file === `${folder}.ts`;
+        });
+
+        console.log(
+            (await import('chalk')).default.yellow(
+                `[${folder}]: Building entrypoint: ${entryPoint}...`,
+            ),
+        );
+
         await watchFolder(
-            folder,
+            path.join(folderPath, entryPoint),
             path.join(__dirname, 'dist', folder),
             folder === 'client' ? ['chrome58'] : undefined,
             folder === 'client' ? 'iife' : 'cjs',

--- a/build.dev.js
+++ b/build.dev.js
@@ -1,68 +1,65 @@
+const chokidar = require('chokidar');
+const { build } = require('esbuild');
+const path = require('path');
 
-async function watch() {
-    const chalk = (await import("chalk")).default
-    const exec = (await import("child_process")).exec;
-    require('esbuild').build({
-        entryPoints: ['client/client.ts'],
-        bundle: true,
-        outfile: 'dist/client.js',
-        target: ["chrome58"],
-        format: "iife",
-        watch: {
-            onRebuild: (err, res) => {
-                if (err) {
-                    console.log(chalk.red("[client]: Rebuild failed :("), err)
-                } else {
-                    console.log(chalk.green("[client]: Rebuild succeeded :), warnings:"), res.warnings)
-                    console.log(chalk.yellow("[client]: Checking types..."))
-                    const p = exec("tsc -p client", (err) => {
-                        if (!err) {
-                            console.log(chalk.green("[client]: Typechecking finished without errors :)"))
-                        } else {
-                            console.log(chalk.red("[client]: Typechecking finished with errors (see above) :("))
-                        }
-                    })
-                    p.stdout.on("data", (d) => {
-                        console.log(chalk.yellow(`[client::typecheck]: ${d.toString()}`))
-                    })
-                }
-            }
-        }
-    }).then((r) => console.log(chalk.green("[client]: Watching..."))).catch((err) => {
-        console.log(err)
-        process.exit(1)
-    })
+async function buildFolder(folder, outdir, target, format, platform) {
+    const chalk = (await import('chalk')).default;
+    console.log(chalk.yellow(`[${folder}]: Building...`));
 
-    require('esbuild').build({
-        entryPoints: ['server/server.ts'],
-        bundle: true,
-        outfile: 'dist/server.js',
-        format: "cjs",
-        platform: "node",
-        watch: {
-            onRebuild: async (err, res) => {
-                if (err) {
-                    console.log(chalk.red("[server]: Rebuild failed :("), err)
-                } else {
-                    console.log(chalk.green("[server]: Rebuild succeeded :), warnings:"), res.warnings)
-                    console.log(chalk.yellow("[server]: Checking types..."))
-                    const p = exec("tsc -p server", (err) => {
-                        if (!err) {
-                            console.log(chalk.green("[server]: Typechecking finished without errors :)"))
-                        } else {
-                            console.log(chalk.red("[server]: Typechecking finished with errors (see above) :("))
-                        }
-                    })
-                    p.stdout.on("data", (d) => {
-                        console.log(chalk.yellow(`[server::typecheck]: ${d.toString()}`))
-                    })
-                }
-            }
-        }
-    }).then(() => console.log(chalk.green("[server]: Watching..."))).catch((err) => {
-        console.log(err)
-        process.exit(1)
-    })
+    try {
+        const files = require('fs')
+            .readdirSync(folder)
+            .filter((file) => file.endsWith('.ts'));
+
+        const entryPoints = files.map((file) =>
+            require('path').join(folder, file),
+        );
+
+        await build({
+            entryPoints,
+            bundle: true,
+            outdir,
+            target,
+            format,
+            platform,
+            minify: false,
+        });
+
+        console.log(chalk.green(`[${folder}]: Built successfully!`));
+    } catch (error) {
+        console.log(chalk.red(`[${folder}]: Build failed!`));
+        console.error(error);
+    }
 }
 
-watch()
+async function watchFolder(folder, outDir, target, format, platform) {
+    const chalk = (await import('chalk')).default;
+    await buildFolder(folder, outDir, target, format, platform);
+
+    const watcher = chokidar.watch(`${folder}/**/*.ts`, {
+        ignoreInitial: true,
+    });
+
+    console.log(chalk.yellow(`[${folder}]: Watching for changes...`));
+
+    watcher.on('change', async (filePath) => {
+        console.log(chalk.yellow(`[${folder}]: File changed: ${filePath}`));
+        await buildFolder(folder, outDir, target, format, platform);
+    });
+}
+
+async function watchAll() {
+    const folders = ['server', 'client'];
+
+    for (const folder of folders) {
+        await watchFolder(
+            folder,
+            path.join(__dirname, 'dist', folder),
+            folder === 'client' ? ['chrome58'] : undefined,
+            folder === 'client' ? 'iife' : 'cjs',
+            folder === 'server' ? 'node' : undefined,
+        );
+    }
+}
+
+watchAll();

--- a/build.prod.js
+++ b/build.prod.js
@@ -2,12 +2,26 @@ const fs = require('fs');
 const path = require('path');
 const { build } = require('esbuild');
 
+function getAllFiles(folder) {
+    let result = [];
+    const files = fs.readdirSync(folder);
+
+    for (const file of files) {
+        const filePath = path.join(folder, file);
+        const stats = fs.statSync(filePath);
+        if (stats.isDirectory()) {
+            result = result.concat(getAllFiles(filePath));
+        } else if (file.endsWith('.ts')) {
+            result.push(filePath);
+        }
+    }
+
+    return result;
+}
+
 async function buildFolder(folder, outdir, target, format, platform) {
     try {
-        const files = fs
-            .readdirSync(folder)
-            .filter((file) => file.endsWith('.ts'));
-        const entryPoints = files.map((file) => path.join(folder, file));
+        const entryPoints = getAllFiles(folder);
 
         await build({
             entryPoints,

--- a/build.prod.js
+++ b/build.prod.js
@@ -1,24 +1,56 @@
-async function build() {
-    const chalk = (await import("chalk")).default
+const fs = require('fs');
+const path = require('path');
+const { build } = require('esbuild');
 
+async function buildFolder(folder, outdir, target, format, platform) {
+    try {
+        const files = fs
+            .readdirSync(folder)
+            .filter((file) => file.endsWith('.ts'));
+        const entryPoints = files.map((file) => path.join(folder, file));
 
-    require('esbuild').build({
-        entryPoints: ['client/client.ts'],
-        bundle: true,
-        outfile: 'dist/client.js',
-        target: ["chrome58"],
-        minify: false,
-        format: "iife",
-    }).then(() => console.log(chalk.green("[client]: Built successfully!"))).catch(() => process.exit(1))
+        await build({
+            entryPoints,
+            bundle: true,
+            outdir,
+            target,
+            format,
+            platform,
+            minify: false,
+        });
 
-    require('esbuild').build({
-        entryPoints: ['server/server.ts'],
-        bundle: true,
-        outfile: 'dist/server.js',
-        format: "cjs",
-        minify: false,
-        platform: "node",
-    }).then(() => console.log(chalk.green("[server]: Built successfully!"))).catch(() => process.exit(1))
+        const folderName = folder.includes('server') ? 'server' : 'client';
+        console.log(
+            (await import('chalk')).default.green(
+                `[${folderName}]: Built successfully!`,
+            ),
+        );
+    } catch (error) {
+        console.error(error);
+        process.exit(1);
+    }
 }
 
-build()
+async function buildAll() {
+    console.log((await import('chalk')).default.yellow('Building...'));
+    const folders = ['server', 'client'];
+
+    for (const folder of folders) {
+        const folderPath = path.join(__dirname, folder);
+        const outDir = path.join(__dirname, 'dist', folder);
+
+        await buildFolder(
+            folderPath,
+            outDir,
+            folder === 'client' ? ['chrome58'] : undefined,
+            folder === 'client' ? 'iife' : 'cjs',
+            folder === 'server' ? 'node' : undefined,
+        );
+    }
+
+    console.log(
+        (await import('chalk')).default.green('Built all successfully!'),
+    );
+}
+
+buildAll();

--- a/client/client.ts
+++ b/client/client.ts
@@ -1,1 +1,1 @@
-console.log("Hello client world!")
+console.log('Hello client world!');

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,9 +1,14 @@
+-- FiveM supported server/game info, don't change unless you know what you're doing
 fx_version 'cerulean'
-
 game 'gta5'
 
+-- Project name
 name 'your-awesome-project'
 
-client_script 'dist/client.js'
-
-server_script 'dist/server.js'
+--[[ 
+    Load our server and client scripts, globbed by the dist folder 
+    to allow all JS files to be loaded. You shouldn't have to change 
+    this unless you're doing something custom.
+ ]]--
+server_script 'dist/server/**/*.js'
+client_script 'dist/client/**/*.js'

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
         "build": "tsc -p server && tsc -p client && node build.prod.js",
         "dev": "node build.dev.js"
     },
-    "dependencies": {},
     "devDependencies": {
         "@citizenfx/client": "^2.0.7521-1",
         "@citizenfx/server": "^2.0.7521-1",
         "@types/node": "^16.3.1",
         "chalk": "^5.3.0",
+        "chokidar": "^3.6.0",
         "esbuild": "^0.20.1",
         "typescript": "^5.3.3"
     }

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,1 +1,1 @@
-console.log("Hello server world!")
+console.log('Hello server world!!');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,12 +4,12 @@
 
 "@citizenfx/client@^2.0.7521-1":
   version "2.0.7521-1"
-  resolved "https://npm.hep.gg/@citizenfx/client/-/client-2.0.7521-1.tgz#4d17839fb7ff14b7e6a501bf92d335b38c939d61"
+  resolved "https://npm.hep.gg/@citizenfx/client/-/client-2.0.7521-1.tgz"
   integrity sha512-53kbTvEOkOWrHHMTG75l6BtW2dDEVmYMU7otPuRvtFpVAXzRuBsdu0aYTYpTHwvh6LIjuwi+tWYw6y8pE/enGQ==
 
 "@citizenfx/server@^2.0.7521-1":
   version "2.0.7521-1"
-  resolved "https://npm.hep.gg/@citizenfx/server/-/server-2.0.7521-1.tgz#54c195fb46045149ee5a92ee2f9fd47d44453f6c"
+  resolved "https://npm.hep.gg/@citizenfx/server/-/server-2.0.7521-1.tgz"
   integrity sha512-NlWqtFMa3gGjHungk2waF7shM+xfAnE50NeAw8Vg1+yqHTnAxZr7zn/hhYLKX/Bk9q+Olk45ZSjdpzUJmMVT7Q==
 
 "@esbuild/aix-ppc64@0.20.1":
@@ -124,22 +124,57 @@
 
 "@esbuild/win32-x64@0.20.1":
   version "0.20.1"
-  resolved "https://npm.hep.gg/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz#77583b6ea54cee7c1410ebbd54051b6a3fcbd8ba"
+  resolved "https://npm.hep.gg/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz"
   integrity sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==
 
 "@types/node@^16.3.1":
   version "16.18.83"
-  resolved "https://npm.hep.gg/@types/node/-/node-16.18.83.tgz#681d1a20676d24fc47e2da3934536304097a81d8"
+  resolved "https://npm.hep.gg/@types/node/-/node-16.18.83.tgz"
   integrity sha512-TmBqzDY/GeCEmLob/31SunOQnqYE3ZiiuEh1U9o3HqE1E2cqKZQA5RQg4krEguCY3StnkXyDmCny75qyFLx/rA==
+
+anymatch@~3.1.2:
+  version "3.1.3"
+  resolved "https://npm.hep.gg/anymatch/-/anymatch-3.1.3.tgz"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://npm.hep.gg/binary-extensions/-/binary-extensions-2.2.0.tgz"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+braces@~3.0.2:
+  version "3.0.2"
+  resolved "https://npm.hep.gg/braces/-/braces-3.0.2.tgz"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 chalk@^5.3.0:
   version "5.3.0"
-  resolved "https://npm.hep.gg/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  resolved "https://npm.hep.gg/chalk/-/chalk-5.3.0.tgz"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+
+chokidar@^3.6.0:
+  version "3.6.0"
+  resolved "https://npm.hep.gg/chokidar/-/chokidar-3.6.0.tgz"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 esbuild@^0.20.1:
   version "0.20.1"
-  resolved "https://npm.hep.gg/esbuild/-/esbuild-0.20.1.tgz#1e4cbb380ad1959db7609cb9573ee77257724a3e"
+  resolved "https://npm.hep.gg/esbuild/-/esbuild-0.20.1.tgz"
   integrity sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==
   optionalDependencies:
     "@esbuild/aix-ppc64" "0.20.1"
@@ -166,7 +201,74 @@ esbuild@^0.20.1:
     "@esbuild/win32-ia32" "0.20.1"
     "@esbuild/win32-x64" "0.20.1"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://npm.hep.gg/fill-range/-/fill-range-7.0.1.tgz"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://npm.hep.gg/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://npm.hep.gg/glob-parent/-/glob-parent-5.1.2.tgz"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://npm.hep.gg/is-binary-path/-/is-binary-path-2.1.0.tgz"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://npm.hep.gg/is-extglob/-/is-extglob-2.1.1.tgz"
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-glob@^4.0.1, is-glob@~4.0.1:
+  version "4.0.3"
+  resolved "https://npm.hep.gg/is-glob/-/is-glob-4.0.3.tgz"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://npm.hep.gg/is-number/-/is-number-7.0.0.tgz"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://npm.hep.gg/normalize-path/-/normalize-path-3.0.0.tgz"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+picomatch@^2.0.4, picomatch@^2.2.1:
+  version "2.3.1"
+  resolved "https://npm.hep.gg/picomatch/-/picomatch-2.3.1.tgz"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://npm.hep.gg/readdirp/-/readdirp-3.6.0.tgz"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://npm.hep.gg/to-regex-range/-/to-regex-range-5.0.1.tgz"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 typescript@^5.3.3:
   version "5.3.3"
-  resolved "https://npm.hep.gg/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  resolved "https://npm.hep.gg/typescript/-/typescript-5.3.3.tgz"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==


### PR DESCRIPTION
This brings this template up to the times of FiveM development, enabling the entire server/ and client/ directories to be built while preserving folder structure.  

- Added folder building for both server/ and client/
- Swapped jank reload system with chokidar
- Misc improvements

**⚠️THIS IS A BREAKING CHANGE. PLEASE SEE BELOW FOR HOW TO MIGRATE ⚠️**

To **migrate:**
1. Replace `build.prod.js` and `build.dev.js` with the new versions from this repo
2. Replace the `fxmanifest.lua`'s  `server_script` and `client_script` with the globbed version from this repo. 
3. Clear your `dist` folder
4. Re-build or re-watch
5. Profit

